### PR TITLE
chore: add prettier and tailwind css plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
-    "extends": ["next/core-web-vitals", "next/typescript"],
-    "rules": {
-        "@typescript-eslint/no-empty-object-type": "off"
-    }
+	"extends": ["next/core-web-vitals", "next/typescript", "prettier"],
+	"rules": {
+		"@typescript-eslint/no-empty-object-type": "off"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": "explicit",
+		"source.organizeImports": "explicit"
+	},
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.formatOnSave": true,
+	"editor.insertSpaces": false,
+	"js/ts.implicitProjectConfig.checkJs": true
+}

--- a/package.json
+++ b/package.json
@@ -1,62 +1,70 @@
 {
-    "name": "board-game-seek",
-    "version": "0.1.0",
-    "private": true,
-    "scripts": {
-        "dev": "next dev",
-        "build": "next build",
-        "start": "next start",
-        "lint": "next lint",
-        "db:index": "node --experimental-strip-types drizzle/index.ts",
-        "db:generate": "drizzle-kit generate",
-        "db:migrate": "drizzle-kit migrate",
-        "db:studio": "drizzle-kit studio"
-    },
-    "dependencies": {
-        "@esbuild-kit/core-utils": "^3.3.2",
-        "@esbuild-kit/esm-loader": "^2.6.5",
-        "@next/env": "^14.2.16",
-        "@radix-ui/react-checkbox": "^1.1.2",
-        "@radix-ui/react-dropdown-menu": "^2.1.2",
-        "@radix-ui/react-icons": "^1.3.0",
-        "@radix-ui/react-slot": "^1.1.0",
-        "@tanstack/react-table": "^8.20.5",
-        "@vercel/postgres": "^0.10.0",
-        "axios": "^1.7.7",
-        "class-variance-authority": "^0.7.0",
-        "clsx": "^2.1.1",
-        "csv-parser": "^3.0.0",
-        "drizzle-orm": "^0.35.3",
-        "fast-xml-parser": "^4.5.0",
-        "lucide-react": "^0.453.0",
-        "next": "15.0.1",
-        "node-fetch": "^3.3.2",
-        "pg": "^8.13.1",
-        "react": "19.0.0-rc-1631855f-20241023",
-        "react-dom": "19.0.0-rc-1631855f-20241023",
-        "tailwind-merge": "^2.5.4",
-        "tailwindcss-animate": "^1.0.7",
-        "tsx": "^4.19.1",
-        "valibot": "^0.42.1"
-    },
-    "devDependencies": {
-        "@types/node": "^20.17.1",
-        "@types/pg": "^8.11.10",
-        "@types/react": "^18.3.12",
-        "@types/react-dom": "^18.3.1",
-        "drizzle-kit": "^0.26.2",
-        "eslint": "^9.13.0",
-        "eslint-config-next": "14.2.15",
-        "postcss": "^8.4.47",
-        "tailwindcss": "^3.4.14",
-        "typescript": "^5.6.3",
-        "ulid": "^2.3.0",
-        "xml-js": "^1.6.11"
-    },
-    "overrides": {
-        "drizzle-orm": {
-            "react": "$react"
-        }
-    },
-    "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
+	"name": "board-game-seek",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"dev": "next dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint",
+		"db:index": "node --experimental-strip-types drizzle/index.ts",
+		"db:generate": "drizzle-kit generate",
+		"db:migrate": "drizzle-kit migrate",
+		"db:studio": "drizzle-kit studio"
+	},
+	"dependencies": {
+		"@esbuild-kit/core-utils": "^3.3.2",
+		"@esbuild-kit/esm-loader": "^2.6.5",
+		"@next/env": "^14.2.16",
+		"@radix-ui/react-checkbox": "^1.1.2",
+		"@radix-ui/react-dropdown-menu": "^2.1.2",
+		"@radix-ui/react-icons": "^1.3.0",
+		"@radix-ui/react-slot": "^1.1.0",
+		"@tanstack/react-table": "^8.20.5",
+		"@vercel/postgres": "^0.10.0",
+		"axios": "^1.7.7",
+		"class-variance-authority": "^0.7.0",
+		"clsx": "^2.1.1",
+		"csv-parser": "^3.0.0",
+		"drizzle-orm": "^0.35.3",
+		"fast-xml-parser": "^4.5.0",
+		"lucide-react": "^0.453.0",
+		"next": "15.0.1",
+		"node-fetch": "^3.3.2",
+		"pg": "^8.13.1",
+		"react": "19.0.0-rc-1631855f-20241023",
+		"react-dom": "19.0.0-rc-1631855f-20241023",
+		"tailwind-merge": "^2.5.4",
+		"tailwindcss-animate": "^1.0.7",
+		"tsx": "^4.19.1",
+		"valibot": "^0.42.1"
+	},
+	"devDependencies": {
+		"@types/node": "^20.17.1",
+		"@types/pg": "^8.11.10",
+		"@types/react": "^18.3.12",
+		"@types/react-dom": "^18.3.1",
+		"drizzle-kit": "^0.26.2",
+		"eslint": "^9.13.0",
+		"eslint-config-next": "14.2.15",
+		"eslint-config-prettier": "^9.1.0",
+		"postcss": "^8.4.47",
+		"prettier": "^3.3.3",
+		"prettier-plugin-tailwindcss": "^0.6.8",
+		"tailwindcss": "^3.4.14",
+		"typescript": "^5.6.3",
+		"ulid": "^2.3.0",
+		"xml-js": "^1.6.11"
+	},
+	"overrides": {
+		"drizzle-orm": {
+			"react": "$react"
+		}
+	},
+	"prettier": {
+		"plugins": [
+			"prettier-plugin-tailwindcss"
+		]
+	},
+	"packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,18 @@ importers:
       eslint-config-next:
         specifier: 14.2.15
         version: 14.2.15(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@9.13.0(jiti@1.21.6))
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.8
+        version: 0.6.8(prettier@3.3.3)
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.14(ts-node@10.9.2(@types/node@20.17.1)(typescript@5.6.3))
@@ -1721,6 +1730,12 @@ packages:
       typescript:
         optional: true
 
+  eslint-config-prettier@9.1.0:
+    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
@@ -2508,6 +2523,66 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-tailwindcss@0.6.8:
+    resolution: {integrity: sha512-dGu3kdm7SXPkiW4nzeWKCl3uoImdd5CTZEJGxyypEPL37Wj0HT2pLqjrvSei1nTeuQfO4PUfjeW5cTUNRLZ4sA==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig-melody': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig-melody':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4376,6 +4451,10 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-prettier@9.1.0(eslint@9.13.0(jiti@1.21.6)):
+    dependencies:
+      eslint: 9.13.0(jiti@1.21.6)
+
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -5207,6 +5286,12 @@ snapshots:
   postgres-range@1.1.4: {}
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-tailwindcss@0.6.8(prettier@3.3.3):
+    dependencies:
+      prettier: 3.3.3
+
+  prettier@3.3.3: {}
 
   prop-types@15.8.1:
     dependencies:


### PR DESCRIPTION
ESLint linter는 이미 설치돼 있으므로, Prettier formatter만 추가 설치합니다. 

Tailwind CSS class-name의 일관된 정렬을 위해서라도 Prettier 사용을 권장합니다. 

Draft 형식으로 게시하는 건 crawling 브랜치 머지 후 일괄 format 작업을 하기 위함입니다. 

--- 

VS Code 상에서 파일을 저장할 때마다 formatting, linting이 이뤄지도록 돼있는데, 이 부분은 지워도 됩니다. 

다만 이를 비활성화할 경우 pre-commit hook을 사용해서 커밋 작성 전에 formatting이 이뤄지도록 해야 합니다.